### PR TITLE
Fix ability to change cluster colors

### DIFF
--- a/kwiklib/dataio/experiment.py
+++ b/kwiklib/dataio/experiment.py
@@ -465,9 +465,9 @@ class Spikes(Node):
         g = self.channel_group_id
         path = '/channel_groups/{}/features_masks'.format(g)
         if files['kwx']:
--            self.features_masks = files['kwx'].getNode(path)
--        else:
--            self.features_masks = None
+            self.features_masks = files['kwx'].getNode(path)
+        else:
+            self.features_masks = None
 
         # Load raw data directly from raw data.
         traces = _read_traces(files)

--- a/kwiklib/dataio/experiment.py
+++ b/kwiklib/dataio/experiment.py
@@ -464,7 +464,10 @@ class Spikes(Node):
         # Load features masks directly from KWX.
         g = self.channel_group_id
         path = '/channel_groups/{}/features_masks'.format(g)
-        self.features_masks = files['kwx'].getNode(path)
+        if files['kwx']:
+-            self.features_masks = files['kwx'].getNode(path)
+-        else:
+-            self.features_masks = None
 
         # Load raw data directly from raw data.
         traces = _read_traces(files)

--- a/kwiklib/dataio/experiment.py
+++ b/kwiklib/dataio/experiment.py
@@ -464,10 +464,7 @@ class Spikes(Node):
         # Load features masks directly from KWX.
         g = self.channel_group_id
         path = '/channel_groups/{}/features_masks'.format(g)
-        if files['kwx']:
-            self.features_masks = files['kwx'].getNode(path)
-        else:
-            self.features_masks = None
+        self.features_masks = files['kwx'].getNode(path)
 
         # Load raw data directly from raw data.
         traces = _read_traces(files)
@@ -701,7 +698,7 @@ class Cluster(Node):
         # self.mean_waveform_raw = self._node._v_attrs.mean_waveform_raw
         # self.mean_waveform_filtered = self._node._v_attrs.mean_waveform_filtered
 
-        # self.application_data = NodeWrapper(self._node.application_data)
+        self.application_data = NodeWrapper(self._node.application_data)
         # self.color = self.application_data.klustaviewa.color
         # self.user_data = NodeWrapper(self._node.user_data)
         # self.quality_measures = NodeWrapper(self._node.quality_measures)

--- a/kwiklib/dataio/kwikloader.py
+++ b/kwiklib/dataio/kwikloader.py
@@ -113,9 +113,8 @@ class KwikLoader(Loader):
             shutil.copyfile(clu, clu_original)
 
         if not kwik:
-            assert xml, ValueError("I need the .xml file!")
-            klusters_to_kwik(filename=xml, dir=dir,
-                progress_report=self._report_progress_open)
+-           assert xml, ValueError("I need a valid .kwik file")
+-           return
 
         self.experiment = Experiment(basename, dir=dir, mode='a')
 

--- a/kwiklib/dataio/kwikloader.py
+++ b/kwiklib/dataio/kwikloader.py
@@ -113,8 +113,9 @@ class KwikLoader(Loader):
             shutil.copyfile(clu, clu_original)
 
         if not kwik:
-            assert xml, ValueError("I need a valid .kwik file")
-            return
+            assert xml, ValueError("I need the .xml file!")
+            klusters_to_kwik(filename=xml, dir=dir,
+                progress_report=self._report_progress_open)
 
         self.experiment = Experiment(basename, dir=dir, mode='a')
 
@@ -253,10 +254,9 @@ class KwikLoader(Loader):
         # self.cluster_colors.ix[clusters] = color
         if not hasattr(clusters, '__len__'):
             clusters = [clusters]
-
         clusters_gr = self.experiment.channel_groups[self.shank].clusters.main
-        # for cl in clusters:
-        #     clusters_gr[cl].application_data.klustaviewa.color = color
+        for cl in clusters:
+            clusters_gr[cl].application_data.klustaviewa.color = color
 
         self.read_clusters()
 

--- a/kwiklib/dataio/kwikloader.py
+++ b/kwiklib/dataio/kwikloader.py
@@ -113,8 +113,8 @@ class KwikLoader(Loader):
             shutil.copyfile(clu, clu_original)
 
         if not kwik:
--           assert xml, ValueError("I need a valid .kwik file")
--           return
+            assert xml, ValueError("I need a valid .kwik file")
+            return
 
         self.experiment = Experiment(basename, dir=dir, mode='a')
 


### PR DESCRIPTION
In the new version of klustaviewa released April 2016 the ability to change the colors of clusters did not work. To fix this I added changes to both the klustaviewa repository and the kwiklib repository (which need to be merged both in order for this fix to work). I implemented the way the old klustaviewa worked by getting the cluster color from the kwik file.